### PR TITLE
Ci/dockerhub publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,14 +3,8 @@ name: docker
 on:
   push:
     branches:
-      - "dev"
-      - "ci/dockerhub-publish"
-  workflow_dispatch:
-    inputs:
-      test_tag:
-        description: "Optional tag for manual test runs (e.g., ci-test)"
-        required: false
-        default: ""
+      - "dev"                  # only dev auto-publishes
+  workflow_dispatch:           # keep manual runs (will show after this is on default branch)
 
 permissions: read-all
 
@@ -57,9 +51,14 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./
-          file: ./docker/Dockerfile.app    # <<— here
+          file: ./docker/Dockerfile.app
           platforms: ${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Speed up subsequent builds
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # If you prefer to hide the "unknown/unknown" attestation entries, uncomment:
+          # provenance: false
           outputs: type=image,"name=${{ env.IMAGE }}",push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest (artifact)
@@ -106,31 +105,4 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           tags: |
-            type=raw,value=latest-stage,enable=${{ github.ref == 'refs/heads/dev' }}
-            type=raw,value=${{ github.event.inputs.test_tag }},enable=${{ github.event.inputs.test_tag != '' }}
-            type=raw,value=ci-test,enable=${{ github.ref == 'refs/heads/ci/dockerhub-publish' }}
-
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
-
-      - name: Inspect resulting image
-        run: |
-          docker buildx imagetools inspect $(jq -r '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-
-  update-description:
-    name: Update Docker Hub Description
-    runs-on: ubuntu-latest
-    needs: [merge]
-    if: success()
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Update description
-        uses: peter-evans/dockerhub-description@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ env.IMAGE }}
+            type=raw,value=latest-stage,enable=${{ github.


### PR DESCRIPTION
Introduce a GitHub Action that builds multi-arch Docker images (amd64 + arm64) from ./docker/Dockerfile.app and pushes them to Docker Hub.