### PR TITLE
Frontend - Botton Ajouter une personne

### DIFF
--- a/app/fiches/templates/fiches/edition/bibliographie.html
+++ b/app/fiches/templates/fiches/edition/bibliographie.html
@@ -287,8 +287,11 @@
                                 <button type="button"
                                     class="dynamiclist_helper_addbut helper_addbut ui-button ui-widget ui-state-default ui-corner-all ui-button-text-icon-primary"
                                     onclick="dynamiclist_widget.addToList(this, 'subj_person'); return false;" role="button"
-                                    aria-disabled="false"><span class="ui-button-icon-primary ui-icon ui-icon-plusthick"></span><span
-                                        class="ui-button-text"><span>Ajouter une personne</span></span></button>
+                                    aria-disabled="false">
+                                    
+                                    <span class="ui-button-icon-primary ui-icon ui-icon-plusthick"></span>
+                                    Ajouter une personne
+                                </button>
                             </span>
                             <span class="dynamiclist_add_info">Validez votre sélection avec le bouton <strong>"Ajouter une personne"</strong></span>
                         </div>


### PR DESCRIPTION
Fixes #60

Clean unecessary span tags


This pull request makes a minor UI improvement to the "Ajouter une personne" button in the bibliography editing template. The change simplifies the button's markup by removing unnecessary nested spans and placing the button text directly after the icon, which improves readability and maintainability.

- UI simplification:
  * [`app/fiches/templates/fiches/edition/bibliographie.html`](diffhunk://#diff-92f28073344f13f17cbfab5863921c4ca762f5e1ce402e5bac43bc2a3eaea598L290-R294): Simplified the "Ajouter une personne" button markup by removing extra nested spans and placing the text directly after the icon.